### PR TITLE
Correct 1 word and add HarmonyOS NEXT aarch64 port onto the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-Welcome to LibHMOS NEXT, a FREE documentation of Huawei's new Indipendent [OS](https://en.wikipedia.org/wiki/Operating_system).
+Welcome to LibHMOS NEXT, a FREE documentation of Huawei's new Independent [OS](https://en.wikipedia.org/wiki/Operating_system).
 You are now in our Website's main page, here you can find all our links:
 
 - [HarmonyOS NEXT x86_64](https://ryzenstechdev.github.io/LibHMOS-NEXT/x86)
+
+- [HarmonyOS NEXT aarch64]
+(https://ryzenstechdev.github.io/LibHMOS-NEXT/arm64)
 
 # Credits:
 - ryzenstech (for creating this website)

--- a/README.md
+++ b/README.md
@@ -3,10 +3,9 @@ You are now in our Website's main page, here you can find all our links:
 
 - [HarmonyOS NEXT x86_64](https://ryzenstechdev.github.io/LibHMOS-NEXT/x86)
 
-- [HarmonyOS NEXT aarch64]
-(https://ryzenstechdev.github.io/LibHMOS-NEXT/arm64)
+- [HarmonyOS NEXT aarch64](https://ryzenstechdev.github.io/LibHMOS-NEXT/arm64)
 
 # Credits:
 - ryzenstech (for creating this website)
 - @NightstarSakura on Telegram (for most of the leaks)
-- @romashkagene on Telegram (for the script
+- @romashkagene on Telegram (for the script)


### PR DESCRIPTION
I found out that there's also 1 page for aarch64, so I added it.